### PR TITLE
Added direct attribute and used $parse for event handling

### DIFF
--- a/angular.tree.js
+++ b/angular.tree.js
@@ -111,6 +111,7 @@
 
         var tree = {
             multiple: 'multiple' in attributes,
+            direct: 'direct' in attributes,
             rootElem: treeElem,
             treeModelExpr: treeModelExpr,
             itemTemplate: $compile(itemTemplate),
@@ -146,7 +147,7 @@
                 var selectedItemElem = findParentListItem(evt.target);
                 var selectedItemScope = selectedItemElem ? selectedItemElem.scope() : null;
 
-                if (evt[multiSelectKey] && tree.multiple) {
+                if ((evt[multiSelectKey] || tree.direct) && tree.multiple) {
                     if (selectedItemScope) {
                         selectedItemScope.$apply(function () {
                             tree.selected(selectedItemScope, ! selectedItemScope.$selected);

--- a/angular.tree.js
+++ b/angular.tree.js
@@ -87,7 +87,7 @@
         });
     }
 
-    function initTree (treeElem, attributes, $compile, $document) {
+    function initTree (treeElem, attributes, $compile, $document, $parse) {
         var itemTemplate = getItemTemplate($document[0], treeElem[0]);
         var treeModelExpr = attributes.src || attributes.ngTree;
         var eachIter = itemTemplate[0].getAttribute('each');
@@ -136,7 +136,10 @@
                     scope.$selected = value;
 
                     if (selectExpr) {
-                        scope.$eval(selectExpr);
+                        var f = $parse(selectExpr);
+                        f(scope, {
+                            '$scope': scope
+                        });
                     }
                 }
             }
@@ -249,10 +252,10 @@
     }
 
     angular.module('angularTree', []).
-        directive('ngTree', ['$compile', '$document', function ($compile, $document) {
+        directive('ngTree', ['$compile', '$document', '$parse', function ($compile, $document, $parse) {
             return {
                 compile: function (elem, attrs) {
-                    var tree = initTree(elem, attrs, $compile, $document);
+                    var tree = initTree(elem, attrs, $compile, $document, $parse);
 
                     return function (scope, elem, attrs) {
                         loadTree(scope, tree, elem, tree.treeModelWatch);

--- a/angular.tree.js
+++ b/angular.tree.js
@@ -131,14 +131,15 @@
 
             trackSelection: !!selectExpr,
 
-            selected: function (scope, value) {
+            selected: function (scope, value, evt) {
                 if (this.trackSelection) {
                     scope.$selected = value;
 
                     if (selectExpr) {
                         var f = $parse(selectExpr);
                         f(scope, {
-                            '$scope': scope
+                            '$scope': scope,
+                            '$event': evt
                         });
                     }
                 }
@@ -153,7 +154,7 @@
                 if ((evt[multiSelectKey] || tree.direct) && tree.multiple) {
                     if (selectedItemScope) {
                         selectedItemScope.$apply(function () {
-                            tree.selected(selectedItemScope, ! selectedItemScope.$selected);
+                            tree.selected(selectedItemScope, ! selectedItemScope.$selected, evt);
                         });
                     }
                 } else {
@@ -163,7 +164,7 @@
 
                             if (itemScope.$selected) {
                                 itemScope.$apply(function () {
-                                    tree.selected(itemScope, false);
+                                    tree.selected(itemScope, false, evt);
                                 });
                             }
                         }
@@ -171,7 +172,7 @@
 
                     if (selectedItemScope && ! selectedItemScope.$selected) {
                         selectedItemScope.$apply(function () {
-                            tree.selected(selectedItemScope, true);
+                            tree.selected(selectedItemScope, true, evt);
                         });
                     }
                 }

--- a/angular.tree.js
+++ b/angular.tree.js
@@ -138,7 +138,6 @@
                     if (selectExpr) {
                         var f = $parse(selectExpr);
                         f(scope, {
-                            '$scope': scope,
                             '$event': evt
                         });
                     }

--- a/angular.tree.js
+++ b/angular.tree.js
@@ -87,6 +87,14 @@
         });
     }
 
+    function selectedProperty(scope,sel) {
+        if (arguments.length > 1) {
+            scope.$selected = sel;
+        } else {
+            return scope.$selected;
+        }
+    }
+
     function initTree (treeElem, attributes, $compile, $document, $parse) {
         var itemTemplate = getItemTemplate($document[0], treeElem[0]);
         var treeModelExpr = attributes.src || attributes.ngTree;
@@ -133,7 +141,7 @@
 
             selected: function (scope, value, evt) {
                 if (this.trackSelection) {
-                    scope.$selected = value;
+                    selectedProperty(scope,value);
 
                     if (selectExpr) {
                         var f = $parse(selectExpr);
@@ -153,7 +161,7 @@
                 if ((evt[multiSelectKey] || tree.direct) && tree.multiple) {
                     if (selectedItemScope) {
                         selectedItemScope.$apply(function () {
-                            tree.selected(selectedItemScope, ! selectedItemScope.$selected, evt);
+                            tree.selected(selectedItemScope, ! selectedProperty(selectedItemScope), evt);
                         });
                     }
                 } else {
@@ -161,7 +169,7 @@
                         if (! selectedItemElem || itemElem[0] !== selectedItemElem[0]) {
                             var itemScope = itemElem.scope();
 
-                            if (itemScope.$selected) {
+                            if (selectedProperty(itemScope)) {
                                 itemScope.$apply(function () {
                                     tree.selected(itemScope, false, evt);
                                 });
@@ -169,7 +177,7 @@
                         }
                     });
 
-                    if (selectedItemScope && ! selectedItemScope.$selected) {
+                    if (selectedItemScope && ! selectedProperty(selectedItemScope)) {
                         selectedItemScope.$apply(function () {
                             tree.selected(selectedItemScope, true, evt);
                         });
@@ -188,7 +196,7 @@
         var itemElem = tree.itemTemplate(itemScope, angular.noop);
 
         if (tree.trackSelection) {
-            itemScope.$selected = false;
+            selectedProperty(itemScope,false);
         }
 
         insertListItem(listElem, itemElem, index);
@@ -242,7 +250,7 @@
             while (listElem.children().length > newList.length) {
                 var removeElem = listElem.children().eq(newList.length);
 
-                if (removeElem.scope().$selected) {
+                if (selectedProperty(removeElem.scope())) {
                     tree.selected(removeElem.scope(), false);
                 }
 

--- a/angular.tree.js
+++ b/angular.tree.js
@@ -145,10 +145,11 @@
             },
 
             selectedProperty: function(scope,value) {
+                var expr = '$selected';
                 if (arguments.length > 1) {
-                    scope.$selected = value;
+                    $parse(expr).assign(scope,value);
                 } else {
-                    return scope.$selected;
+                    return $parse(expr)(scope);
                 }
             }
         };

--- a/angular.tree.js
+++ b/angular.tree.js
@@ -87,14 +87,6 @@
         });
     }
 
-    function selectedProperty(scope,sel) {
-        if (arguments.length > 1) {
-            scope.$selected = sel;
-        } else {
-            return scope.$selected;
-        }
-    }
-
     function initTree (treeElem, attributes, $compile, $document, $parse) {
         var itemTemplate = getItemTemplate($document[0], treeElem[0]);
         var treeModelExpr = attributes.src || attributes.ngTree;
@@ -141,7 +133,7 @@
 
             selected: function (scope, value, evt) {
                 if (this.trackSelection) {
-                    selectedProperty(scope,value);
+                    this.selectedProperty(scope,value);
 
                     if (selectExpr) {
                         var f = $parse(selectExpr);
@@ -149,6 +141,14 @@
                             '$event': evt
                         });
                     }
+                }
+            },
+
+            selectedProperty: function(scope,value) {
+                if (arguments.length > 1) {
+                    scope.$selected = value;
+                } else {
+                    return scope.$selected;
                 }
             }
         };
@@ -161,7 +161,7 @@
                 if ((evt[multiSelectKey] || tree.direct) && tree.multiple) {
                     if (selectedItemScope) {
                         selectedItemScope.$apply(function () {
-                            tree.selected(selectedItemScope, ! selectedProperty(selectedItemScope), evt);
+                            tree.selected(selectedItemScope, ! tree.selectedProperty(selectedItemScope), evt);
                         });
                     }
                 } else {
@@ -169,7 +169,7 @@
                         if (! selectedItemElem || itemElem[0] !== selectedItemElem[0]) {
                             var itemScope = itemElem.scope();
 
-                            if (selectedProperty(itemScope)) {
+                            if (tree.selectedProperty(itemScope)) {
                                 itemScope.$apply(function () {
                                     tree.selected(itemScope, false, evt);
                                 });
@@ -177,7 +177,7 @@
                         }
                     });
 
-                    if (selectedItemScope && ! selectedProperty(selectedItemScope)) {
+                    if (selectedItemScope && ! tree.selectedProperty(selectedItemScope)) {
                         selectedItemScope.$apply(function () {
                             tree.selected(selectedItemScope, true, evt);
                         });
@@ -196,7 +196,7 @@
         var itemElem = tree.itemTemplate(itemScope, angular.noop);
 
         if (tree.trackSelection) {
-            selectedProperty(itemScope,false);
+            tree.selectedProperty(itemScope,false);
         }
 
         insertListItem(listElem, itemElem, index);
@@ -250,7 +250,7 @@
             while (listElem.children().length > newList.length) {
                 var removeElem = listElem.children().eq(newList.length);
 
-                if (selectedProperty(removeElem.scope())) {
+                if (tree.selectedProperty(removeElem.scope())) {
                     tree.selected(removeElem.scope(), false);
                 }
 

--- a/angular.tree.js
+++ b/angular.tree.js
@@ -54,7 +54,7 @@
 
                     childNode.appendChild(wrapperEl);
                 }
-                
+
                 var ulEl = document.createElement('UL');
                 ulEl.className = treeElem.className;
                 childNode.appendChild(ulEl);
@@ -241,7 +241,7 @@
                 if (removeElem.scope().$selected) {
                     tree.selected(removeElem.scope(), false);
                 }
-                
+
                 removeElem.remove();
             }
         }, true);

--- a/angular.tree.js
+++ b/angular.tree.js
@@ -94,7 +94,7 @@
         var contextName = 'item';
         var collectionExpr = 'item.children';
         var selectExpr = itemTemplate.attr('select');
-        var selectedName = itemTemplate.attr('selected');
+        var selectedExpr = itemTemplate[0].getAttribute('selected')||'$selected';
 
         if (eachIter) {
             var match = /^\s*(\w+)\s+in\s+(.*?)\s*$/.exec(eachIter);
@@ -145,11 +145,10 @@
             },
 
             selectedProperty: function(scope,value) {
-                var expr = '$selected';
                 if (arguments.length > 1) {
-                    $parse(expr).assign(scope,value);
+                    $parse(selectedExpr).assign(scope,value);
                 } else {
-                    return $parse(expr)(scope);
+                    return $parse(selectedExpr)(scope);
                 }
             }
         };


### PR DESCRIPTION
I added a direct attribute to be able to prevent the need for modifier keys. E.g.

``` html
<ul ng-tree="model" multiple direct>
```

will always use multiple selection

Furthermore, the `$event` is now sent along with the `select` handler. This way, one can do

``` html
<ul ng-tree="model">
    <li select="selected($event)">{{item.name}}</li>
</ul>
```

``` javascript
$scope.selected = function (e) {
    console.log(this.item.name + ' is selected: ' + this.$selected);
    console.log('event',e);
};
```
